### PR TITLE
Updated readme, fixed error

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -15,10 +15,13 @@
 .prettierrc
 .eslintrc.js
 .eslintignore
+.stylelintrc.js
+.stylelintignore
+.gitattributes
 CLAUDE.md
 composer.json
 jest.config.js
-package-lock.json
+junit.xml
 package.json
 phpcs.xml
 phpstan.neon

--- a/echodash.php
+++ b/echodash.php
@@ -11,7 +11,7 @@
  * Plugin Name: EchoDash
  * Plugin URI:  https://echodash.com/
  * Description: Track events from WordPress plugins as real-time activities in the EchoDash platform.
- * Version:     2.0.0
+ * Version:     2.0.1
  * Author:      EchoDash
  * Text Domain: echodash
  * Domain Path: /languages
@@ -47,7 +47,7 @@
 // Exit if accessed directly.
 defined( 'ABSPATH' ) || exit;
 
-define( 'ECHODASH_VERSION', '2.0.0' );
+define( 'ECHODASH_VERSION', '2.0.1' );
 
 /**
  * Class EchoDash

--- a/echodash.php
+++ b/echodash.php
@@ -260,7 +260,6 @@ final class EchoDash {
 			'wordpress'               => 'WP',
 			'user'                    => 'WP_User',
 			'presto-player'           => 'PrestoPlayer\Core',
-			'abandoned-cart'          => 'WP_Fusion_Abandoned_Cart',
 			'gravity-forms'           => 'GFForms',
 			'affiliatewp'             => 'Affiliate_WP',
 			'bbpress'                 => 'bbPress',

--- a/readme.txt
+++ b/readme.txt
@@ -35,6 +35,7 @@ We will always offer a free tier of service with an activity feed. As we add rep
 * **AffiliateWP** - Track referrals and affiliate activity
 * **bbPress** - Track forum activity and user engagement
 * **BuddyPress + BuddyBoss** - Follow group activities, profile updates, and member interactions
+* **ClickWhale** - Track outbound link clicks
 * **Easy Digital Downloads** - Monitor purchases and downloads
 * **EDD Recurring** - Track subscription payments and renewals
 * **EDD Software Licensing** - Monitor license activations and software updates
@@ -44,9 +45,11 @@ We will always offer a free tier of service with an activity feed. As we add rep
 * **LearnDash** - Monitor course progress, quiz completions, and student engagement
 * **LifterLMS** - Follow student progress and course interactions
 * **Presto Player** - Track video engagement and watch time
+* **Pretty Links** - Track outbound link clicks
+* **SearchWP** - Track search queries and results
 * **WooCommerce** - Track orders, cart actions, and customer behavior
 * **WooCommerce Subscriptions** - Monitor subscription status changes and renewals
-* **WordPress** - Track core and plugin updates
+* **WordPress** - Track core and plugin updates, post status changes, and comments
 * **Users** - Track user logins
 
 = Not Limited to WordPress =
@@ -127,11 +130,14 @@ Yes, developers can use our API to track custom events. Documentation is availab
 
 == Changelog ==
 
+= 2.0.1 - August 11, 2025 =
+* Fixed fatal error `failed opening required class-echodash-abandoned-cart.php` when the WP Fusion Abandoned Cart plugin is active
+
 = 2.0.0 - August 10, 2025 =
 * New React-based admin UI
-* Added AffiliateWP integration: New Affiliate, Affiliate Status Updated, New Visit, Referral Earned)
+* Added AffiliateWP integration: New Affiliate, Affiliate Status Updated, New Visit, Referral Earned
 * Added SearchWP integration: Search Performed, Search No Results
-* Added PrettyLinks integration: Outbound Link Click
+* Added Pretty Links integration: Outbound Link Click
 * Added ClickWhale integration: Outbound Link Click
 * Added new WordPress core triggers: New Post Comment, New Comment Reply, Post Published, Post Updated, Post Status Changed
 * Added trigger: Easy Digital Downloads - Discount Used

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: analytics, tracking, activity, log, events
 Requires at least: 6.0
 Tested up to: 6.8.3
 Requires PHP: 7.4
-Stable tag: 2.0.0
+Stable tag: 2.0.1
 License: GPLv3 or later
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Prevents a fatal error when the WP Fusion Abandoned Cart plugin is active by no longer loading that integration.

- Documentation
  - Expanded Supported Integrations: ClickWhale (Outbound Link Click), Pretty Links (Outbound Link Click), SearchWP (search queries/results).
  - WordPress integration docs now include tracking for comments and post status changes.
  - Changelog updated (2.0.1 fix note; 2.0.0 text corrections).
  - Naming/formatting cleanups (AffiliateWP line, Pretty Links naming).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->